### PR TITLE
django.core.urlresolvers removed in Django 2

### DIFF
--- a/instant/urls.py
+++ b/instant/urls.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from django import VERSION
-if VERSION > (2, 0):
+if VERSION >= (2, 0):
     from django.urls import reverse_lazy
 else:
     from django.core.urlresolvers import reverse_lazy

--- a/instant/urls.py
+++ b/instant/urls.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from django.core.urlresolvers import reverse_lazy
+from django.urls import reverse_lazy
 from django.conf.urls import url
 from django.views.generic import RedirectView
 from instant.views import FrontendView, StaffChannelView, PostMsgView

--- a/instant/urls.py
+++ b/instant/urls.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 
-from django.urls import reverse_lazy
+import sys
+if (sys.version_info > (3, 0)):
+    from django.urls import reverse_lazy
+else:
+    from django.core.urlresolvers import reverse_lazy
 from django.conf.urls import url
 from django.views.generic import RedirectView
 from instant.views import FrontendView, StaffChannelView, PostMsgView

--- a/instant/urls.py
+++ b/instant/urls.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-import sys
-if (sys.version_info > (3, 0)):
+from django import VERSION
+if VERSION > (2, 0):
     from django.urls import reverse_lazy
 else:
     from django.core.urlresolvers import reverse_lazy

--- a/instant/views.py
+++ b/instant/views.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 import json
+import sys
 from django.http import JsonResponse
-from django.urls import reverse
+if (sys.version_info > (3, 0)):
+    from django.urls import reverse
+else:
+    from django.core.urlresolvers import reverse
 from django.http.response import Http404
 from django.views.generic.base import View
 from django.views.generic import FormView

--- a/instant/views.py
+++ b/instant/views.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import json
 from django.http import JsonResponse
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http.response import Http404
 from django.views.generic.base import View
 from django.views.generic import FormView

--- a/instant/views.py
+++ b/instant/views.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 import json
-import sys
+from django import VERSION
+
 from django.http import JsonResponse
-if (sys.version_info > (3, 0)):
+if VERSION >= (2, 0):
     from django.urls import reverse
 else:
     from django.core.urlresolvers import reverse


### PR DESCRIPTION
Hello,

find this small contribution to improve python 3 compat.
```
django.core.urlresolvers
```

change to

```
django.urls
```

regards