### PR TITLE
CENTRIFUGO_PROXY parameter

### DIFF
--- a/docs/src/install.rst
+++ b/docs/src/install.rst
@@ -6,15 +6,15 @@ Install and configure
 ::
 
    pip install django-instant
-   
-   
+
+
 Add to installed apps:
 
 ::
 
    "corsheaders",
    "instant",
-   
+
 2. Install the websockets server
 
 An installer is available for Linux only:
@@ -24,11 +24,11 @@ An installer is available for Linux only:
 ::
 
    python3 manage.py installws
-   
-This will download the Centrifugo websockets server, install it and update your settings.py 
+
+This will download the Centrifugo websockets server, install it and update your settings.py
 file with the appropriate configuration.
 
-For other systems you have to install 
+For other systems you have to install
 Centrifugo `manually <https://fzambia.gitbooks.io/centrifugal/content/server/start.html>`_ (use version
 1 as this module is not compatible with Centrifugo 2 yet)
 
@@ -46,7 +46,7 @@ Configure the middleware:
       ...
    ]
 
-Note: if you use the management command to install the server the settings below will already 
+Note: if you use the management command to install the server the settings below will already
 be configured.
 
 ::
@@ -55,19 +55,19 @@ be configured.
    CENTRIFUGO_SECRET_KEY = "70b651f6-775a-4949-982b-b387b31c1d84" # the_key_that_is_in_config.json
    SITE_SLUG = "my_site" # used internaly to prefix the channels
    SITE_NAME = "My site"
-   
+
    CORS_ORIGIN_WHITELIST = ('localhost:8001',)
-   
+
    # optionnal settings
    CENTRIFUGO_HOST = 'http://ip_here' #default: localhost
    CENTRIFUGO_PORT = 8012 # default: 8001
+   CENTRIFUGO_PROXY = True # default: False - remove port from URL if you are behind a proxy.
 
-   
-By default the events are published using python. A go module is available to perform the 
-publish operations in order to leave the main process alone as much as possible. 
-This might be usefull when lots of messages are sent. 
+By default the events are published using python. A go module is available to perform the
+publish operations in order to leave the main process alone as much as possible.
+This might be usefull when lots of messages are sent.
 
-Note: when this option is enabled there is no error handling. This option is recommended 
+Note: when this option is enabled there is no error handling. This option is recommended
 when you need higher performance and don't care about error messages.
 
 You might have to make the `instant/go/publish` file executable with `chmod`
@@ -77,7 +77,7 @@ You might have to make the `instant/go/publish` file executable with `chmod`
 ::
 
    INSTANT_BROADCAST_WITH = 'go'
-   
+
 Performance test: 1000 messages:
 
 - Python: 2.96 seconds
@@ -88,14 +88,14 @@ Performance test: 1000 messages:
 - Python: 29.57 seconds
 - Go: 14.44 seconds
 
-Note: this test uses the standard publish function so that each new event sent makes an 
+Note: this test uses the standard publish function so that each new event sent makes an
 new connection to Centrifugo.
 
 Templates
 ~~~~~~~~~
 
-Include the template ``{% include "instant/client.html" %}`` anywhere: nothing will 
-be displayed it is the engine. See next section for messages handling. 
+Include the template ``{% include "instant/client.html" %}`` anywhere: nothing will
+be displayed it is the engine. See next section for messages handling.
 
 Run the websockets server
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -107,7 +107,7 @@ If you used the installer:
 ::
 
    python3 manage.py runws
-   
+
 Otherwise run the Centrifugo server normally
 
 Frontend
@@ -121,7 +121,7 @@ A demo frontend is available. To use it:
 ::
 
    pip install django-vitevue
-   
+
 Add `"vv",` to installed apps
 
 Set the urls:
@@ -131,7 +131,7 @@ Set the urls:
 ::
 
    from instant.views import instant_auth
-   
+
    urlpatterns = [
    	# ...
    	url(r'^centrifuge/auth/$', instant_auth, name='instant-auth'),

--- a/instant/conf.py
+++ b/instant/conf.py
@@ -4,6 +4,7 @@ from django.conf import settings
 SECRET_KEY = getattr(settings, 'CENTRIFUGO_SECRET_KEY', "secret_key")
 CENTRIFUGO_HOST = getattr(settings, 'CENTRIFUGO_HOST', 'http://localhost')
 CENTRIFUGO_PORT = getattr(settings, 'CENTRIFUGO_PORT', 8001)
+CENTRIFUGO_PROXY = getattr(settings, 'CENTRIFUGO_PROXY', False)
 
 SITE_SLUG = getattr(settings, 'SITE_SLUG', 'site')
 SITE_NAME = getattr(settings, 'SITE_NAME', 'Site')

--- a/instant/producers.py
+++ b/instant/producers.py
@@ -35,7 +35,7 @@ def _get_channel(channel, target):
 def publish_py(message, channel=None, event_class="default", data=None,
                site=SITE_NAME, target=None):
     cent_url = CENTRIFUGO_HOST + ":" + str(CENTRIFUGO_PORT)
-    if CENTRIFUGO_PROXY:
+    if CENTRIFUGO_PROXY is True:
         cent_url = CENTRIFUGO_HOST
     client = Client(cent_url, SECRET_KEY, timeout=1)
     channel = _get_channel(channel, target)

--- a/instant/producers.py
+++ b/instant/producers.py
@@ -34,11 +34,9 @@ def _get_channel(channel, target):
 
 def publish_py(message, channel=None, event_class="default", data=None,
                site=SITE_NAME, target=None):
+    cent_url = CENTRIFUGO_HOST + ":" + str(CENTRIFUGO_PORT)
     if CENTRIFUGO_PROXY:
         cent_url = CENTRIFUGO_HOST
-    else:
-        cent_url = CENTRIFUGO_HOST + ":" + str(CENTRIFUGO_PORT)
-
     client = Client(cent_url, SECRET_KEY, timeout=1)
     channel = _get_channel(channel, target)
     if data is None:

--- a/instant/producers.py
+++ b/instant/producers.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 import json
 from cent import Client, CentException
 from instant.conf import SITE_NAME, CENTRIFUGO_HOST, CENTRIFUGO_PORT, SECRET_KEY, \
-    SITE_SLUG, PUBLIC_CHANNEL, BROADCAST_WITH
+    SITE_SLUG, PUBLIC_CHANNEL, BROADCAST_WITH, CENTRIFUGO_PROXY
 if BROADCAST_WITH == "go":
     import os
     import instant
@@ -34,7 +34,11 @@ def _get_channel(channel, target):
 
 def publish_py(message, channel=None, event_class="default", data=None,
                site=SITE_NAME, target=None):
-    cent_url = CENTRIFUGO_HOST + ":" + str(CENTRIFUGO_PORT)
+    if CENTRIFUGO_PROXY:
+        cent_url = CENTRIFUGO_HOST
+    else:
+        cent_url = CENTRIFUGO_HOST + ":" + str(CENTRIFUGO_PORT)
+
     client = Client(cent_url, SECRET_KEY, timeout=1)
     channel = _get_channel(channel, target)
     if data is None:

--- a/instant/templatetags/instant_tags.py
+++ b/instant/templatetags/instant_tags.py
@@ -55,10 +55,10 @@ class NoHandlerException(Exception):
 
 @register.simple_tag
 def get_centrifugo_url():
+    centrifugo_url = CENTRIFUGO_HOST + ":" + str(CENTRIFUGO_PORT)
     if CENTRIFUGO_PROXY:
-        return CENTRIFUGO_HOST
-    else:
-        return CENTRIFUGO_HOST + ":" + str(CENTRIFUGO_PORT)
+         centrifugo_url = CENTRIFUGO_HOST
+    return centrifugo_url
 
 
 @register.simple_tag

--- a/instant/templatetags/instant_tags.py
+++ b/instant/templatetags/instant_tags.py
@@ -56,7 +56,7 @@ class NoHandlerException(Exception):
 @register.simple_tag
 def get_centrifugo_url():
     centrifugo_url = CENTRIFUGO_HOST + ":" + str(CENTRIFUGO_PORT)
-    if CENTRIFUGO_PROXY:
+    if CENTRIFUGO_PROXY is True:
          centrifugo_url = CENTRIFUGO_HOST
     return centrifugo_url
 

--- a/instant/templatetags/instant_tags.py
+++ b/instant/templatetags/instant_tags.py
@@ -18,6 +18,7 @@ except ImportError:
 SITE_SLUG = getattr(settings, 'SITE_SLUG', 'site')
 CENTRIFUGO_HOST = getattr(settings, 'CENTRIFUGO_HOST', 'http://localhost')
 CENTRIFUGO_PORT = getattr(settings, 'CENTRIFUGO_PORT', 8001)
+CENTRIFUGO_PROXY = getattr(settings, 'CENTRIFUGO_PROXY', False)
 
 APPS = getattr(settings, 'INSTANT_APPS', [])
 
@@ -54,7 +55,10 @@ class NoHandlerException(Exception):
 
 @register.simple_tag
 def get_centrifugo_url():
-    return CENTRIFUGO_HOST + ":" + str(CENTRIFUGO_PORT)
+    if CENTRIFUGO_PROXY:
+        return CENTRIFUGO_HOST
+    else:
+        return CENTRIFUGO_HOST + ":" + str(CENTRIFUGO_PORT)
 
 
 @register.simple_tag
@@ -137,9 +141,9 @@ def get_handlers_url(chan):
         url = HANDLERS[chan]
     else:
         if DEFAULT_HANDLER is None:
-            raise NoHandlerException("No handler found for channel " + 
-                                     "and no default handler is set. " + 
-                                     "Please set a default handler or " + 
+            raise NoHandlerException("No handler found for channel " +
+                                     "and no default handler is set. " +
+                                     "Please set a default handler or " +
                                      "a handler for channel " + chan)
         else:
             url = DEFAULT_HANDLER


### PR DESCRIPTION
For now, could not use django-instant behind a proxy without redirecting centrifugo port.

With this parameter, if CENTRIFUGO_PROXY is True in application.settings,  CENTRIFUGO_PORT will be  removed from CENTRIFUGO_URL.

Upstream server (example for Nginx will manage port redirection)

CENTRIFUGO_PROXY default is False