### PR TITLE
Use Django enumeration-types to avoid typo errors

### DIFF
--- a/instant/models.py
+++ b/instant/models.py
@@ -6,7 +6,7 @@ from .init import ensure_channel_is_private
 
 class ChannelManager(models.Manager):
     def for_user(self, user):
-        filter_from = [Channel.level.Public, Channel.level.Users]
+        filter_from = [Channel.Level.Public, Channel.Level.Users]
         if user.is_superuser:
             filter_from.append(Channel.Level.Superuser)
         if user.is_staff:

--- a/instant/models.py
+++ b/instant/models.py
@@ -4,23 +4,13 @@ from django.utils.translation import gettext_lazy as _
 
 from .init import ensure_channel_is_private
 
-
-LEVELS = (
-    ("public", "Public"),
-    ("users", "Users"),
-    ("groups", "Groups"),
-    ("staff", "Staff"),
-    ("superuser", "Superuser"),
-)
-
-
 class ChannelManager(models.Manager):
     def for_user(self, user):
-        filter_from = ["public", "users"]
+        filter_from = [Channel.level.Public, Channel.level.Users]
         if user.is_superuser:
-            filter_from.append("superuser")
+            filter_from.append(Channel.Level.Superuser)
         if user.is_staff:
-            filter_from.append("staff")
+            filter_from.append(Channel.Level.Staff)
         chans = Channel.objects.filter(
             is_active=True, groups__in=user.groups.all()
         ) | Channel.objects.filter(level__in=filter_from, is_active=True)
@@ -28,6 +18,13 @@ class ChannelManager(models.Manager):
 
 
 class Channel(models.Model):
+    class Level(models.TextChoices):
+        Public = "public"
+        Users = "users"
+        Groups = "groups"
+        Staff = "staff"
+        Superuser = "superuser"
+
     name = models.CharField(
         max_length=120,
         verbose_name=_("Name"),
@@ -36,7 +33,7 @@ class Channel(models.Model):
     )
     level = models.CharField(
         max_length=20,
-        choices=LEVELS,
+        choices=Level.choices,
         verbose_name=_("Authorized for"),
         default="superuser",
     )

--- a/instant/tests/test_model.py
+++ b/instant/tests/test_model.py
@@ -13,7 +13,7 @@ class InstantTestCreate(InstantBaseTest):
         self.assertEqual(str(chan), "$chan")
 
     def test_public_channel_creation(self):
-        chan = Channel.objects.create(name="chan", level="public")
+        chan = Channel.objects.create(name="chan", level=Channel.Level.Public)
         self.assertEqual(chan.name, "chan")
         self.assertEqual(chan.level, "public")
 

--- a/instant/tests/test_model.py
+++ b/instant/tests/test_model.py
@@ -13,9 +13,15 @@ class InstantTestCreate(InstantBaseTest):
         self.assertEqual(str(chan), "$chan")
 
     def test_public_channel_creation(self):
+        chan = Channel.objects.create(name="chan", level="public")
+        self.assertEqual(chan.name, "chan")
+        self.assertEqual(chan.level, "public")
+
+    def test_public_channel_creation_enum(self):
         chan = Channel.objects.create(name="chan", level=Channel.Level.Public)
         self.assertEqual(chan.name, "chan")
         self.assertEqual(chan.level, "public")
+        
 
     def test_channel_manager(self):
         Channel.objects.create(name="$chan")


### PR DESCRIPTION
Hi @synw 
I'm using `django-instant` a lot, and i recommend the use of[ enumeration-types](https://docs.djangoproject.com/en/4.1/ref/models/fields/#enumeration-types) for the `Channel.level.choices`, to have a cleaner use of the LEVEL values programmatically and to avoid typo errors

By using the `models.TextChoices`  we can ease the use of the `Channel.level` values  directly, so instead of 
```
Channel.objects.create(name="superuser", level="superuser") 
```
we can replace it by 
```
Channel.objects.create(name="superuser", level=Channel.Level.Superuser) 
```

NB: No migrations generated/added because the choices are exactly the same

What do you think ? 